### PR TITLE
Change absolute paths to relative paths v0.11

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*.swp
+
+terraform.tfstate
+terraform.tfstate.*
+
+.terraform
+.terragrunt-cache

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,11 @@
+pipeline:
+  build:
+    image: hashicorp/terraform
+    commands:
+      - apk add make
+      - make tfc
+  linter:
+    image: python:3
+    commands:
+      - pip3 install --extra-index-url https://pip-test.techservices.illinois.edu/index/test tflint
+      - make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.swp
+
+terraform.tfstate
+terraform.tfstate.*
+
+.terraform
+.terragrunt-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM hashicorp/terraform
+
+RUN apk add make
+
+WORKDIR /tmp
+COPY . /tmp
+
+ENTRYPOINT [ "/usr/bin/make", "tfc" ]
+
+FROM python:3
+
+RUN pip3 install --extra-index-url https://pip-test.techservices.illinois.edu/index/test tflint
+
+WORKDIR /tmp
+COPY . /tmp
+
+ENTRYPOINT [ "/usr/bin/make", "test" ]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 by the Board of Trustees of the University of Illinois.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,74 @@
+.PHONY: test tfc clean docker sh shell
+
+REPO := $(shell basename $(shell git remote get-url origin) .git)
+
+GOPTS := -lR . -e
+GREP := grep $(GOPTS)
+EGREP := egrep $(GOPTS)
+SRCS := --include=*.tf
+DOCS := --include=README.md
+
+all: tfc test
+
+tfc: .terraform
+	@# Basic Terraform validation and formating checks
+	terraform version
+	AWS_DEFAULT_REGION=us-east-2 terraform validate
+	terraform fmt -check
+
+# Create .terraform if does not exist
+# A terraform init is requried to run a validate :-(
+.terraform:
+	terraform init -backend=false
+	terraform version
+
+test:
+	@####################################################
+	! $(EGREP) "TF-UPGRADE-TODO|cites-illinois|as-aws-modules" $(SRCS) $(DOCS)
+	# Do NOT put terraform-aws in the title of the top-level README
+	! grep "#\s*terraform-aws-" README.md
+	# Do NOT use type string when you can use type number or bool!
+	! $(EGREP) '"\d+"|"true"|"false"' $(SRCS) $(DOCS)
+	# Do NOT use old style maps in docs
+	! $(EGREP) "\w+\s*\{" $(DOCS)
+	# Do NOT drop the "s" in outputs.tf or variables.tf!
+	! find . -name output.tf -o -name variable.tf | grep '.*'
+	# Do NOT define an output in files other than outputs.tf
+	! $(EGREP) 'output\s+"\w+"\s*\{' $(SRCS) --exclude=outputs.tf
+	# Do NOT define a variable in files other than variables.tf
+	! $(EGREP) 'variable\s+"\w+"\s*\{' $(SRCS) --exclude=variables.tf
+	# DO put a badge in top-level README.md
+	grep -q "\[\!\[Build Status\]([^)]*$(REPO)/status.svg)\]([^)]*$(REPO))" README.md
+	# Do NOT split a source line over more than one line
+	! $(GREP) 'source\s*=\s*$$' $(SRCS) $(DOCS)
+	# Do NOT use ?ref= in source lines in a README.md!
+	! $(GREP) 'source\s*=.*?ref=' $(DOCS)
+	# Do NOT start a source line with git::
+	! $(GREP) 'source\s*=\s*"git::' $(SRCS) $(DOCS)
+	# Do NOT use .git in a source line
+	! $(GREP) 'source\s*=.*\.git.*"' $(SRCS) $(DOCS)
+	# Do NOT use double slashes with top-level modules
+	! $(GREP) 'source\s*=.*//?ref=.*"' $(SRCS) $(DOCS)
+	# Do NOT leave extra whitespace at the end of a line
+	! $(EGREP) '\s+$$' $(SRCS)
+	# Do NOT leave empty lines at the start or end of a file
+	! find . -type f -name "*.tf" -exec sh -c "awk 'NR==1; END{print}' {} | egrep -q '^\s*$$' && echo {}" \; | grep '.*'
+	@# Run tflint if it is installed
+	@if which tflint >/dev/null; then tflint ; fi
+
+# Launches the Makefile inside a container
+docker: 
+	docker build . -t test/$(REPO)
+	docker run --rm test/$(REPO)
+
+# Create alias
+sh: shell
+
+# Launches the shell inside a container for debugging the Makefile
+shell:
+	docker build . -t test/$(REPO)
+	docker run -it --rm --entrypoint=sh test/$(REPO)
+
+clean:
+	-rm -rf .terraform
+	-docker rmi -f test/$(REPO) >/dev/null 2>&1

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # aes128-key-rotation
 
-Provides a lambda function to generate base64 encoded AES128 keys
-for [Secret Manager](https://aws.amazon.com/secrets-manager/).
+[![Build Status](https://drone.techservices.illinois.edu/api/badges/techservicesillinois/terraform-aws-aes128-key-rotation/status.svg)](https://drone.techservices.illinois.edu/techservicesillinois/terraform-aws-aes128-key-rotation)
+
+Provides a lambda function, IAM role, and policy to generate base64 encoded AES128 keys
+for [Secret Manager](https://aws.amazon.com/secrets-manager/). This
+may be used with module
+[shibd-data-sealer](https://github.com/techservicesillinois/terraform-aws-shibd-data-sealer).
 
 Argument Reference
 -----------------
 
-No arguments are supported.
+The following arguments are supported:
+
+* `name` - Lambda function name (Default aes128-key-rot).
+
+* `role` - Role name (Default AWSLambdaSecretManagerRole).
+
+* `policy` - Policy name (Default AWSLambdaSecretManager).
 
 Attributes Reference
 --------------------
@@ -17,10 +27,3 @@ The following attributes are exported:
 Lambda Function Version.
 
 * `version` - Latest published version of your Lambda Function.
-
-Credits
---------------------
-
-**Nota bene** the vast majority of the verbiage on this page was
-taken directly from the Terraform manual, and in a few cases from
-Amazon's documentation.

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,5 @@
 data "aws_region" "current" {}
 
-data "aws_caller_identity" "current" {}
-
 data "aws_iam_policy_document" "lambda" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -16,8 +14,12 @@ data "aws_iam_policy_document" "lambda" {
   }
 }
 
+# https://github.com/hashicorp/terraform/issues/8204#issuecomment-332239294
+# In Terraform v0.12 path.module is "./". In v0.11 it is a full path which
+# causes changes when changing paths, even though the hash does not change.
+# Further, ignoring filename changes does not help :-(
 data "archive_file" "selected" {
   type        = "zip"
-  source_file = "${path.module}/lambda.py"
-  output_path = "${path.module}/lambda.zip"
+  source_file = "./lambda.py"
+  output_path = "./lambda.zip"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "default" {
-  name               = "AWSLambdaSecretManagerRole"
+  name               = "${var.role}"
   assume_role_policy = "${data.aws_iam_policy_document.lambda.json}"
 }
 
@@ -14,7 +14,7 @@ resource "aws_iam_role_policy_attachment" "default" {
 }
 
 resource "aws_iam_policy" "default" {
-  name   = "AWSLambdaSecretManage"
+  name   = "${var.policy}"
   path   = "/"
   policy = "${data.aws_iam_policy_document.default.json}"
 }
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "default" {
       test     = "StringEquals"
       variable = "secretsmanager:resource/AllowRotationLambdaArn"
 
-      values = ["arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${local.function_name}"]
+      values = ["${aws_lambda_function.default.arn}"]
     }
 
     actions = [

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,8 @@
-locals {
-  function_name = "aes128-key-rot"
-}
-
 resource "aws_lambda_function" "default" {
-  function_name = "${local.function_name}"
+  function_name = "${var.name}"
   description   = "Generate random AES 128 keys"
   handler       = "lambda.lambda_handler"
-  publish       = "true"
+  publish       = true
 
   role    = "${aws_iam_role.default.arn}"
   runtime = "python3.6"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  description = "Lambda function name"
+  default     = "aes128-key-rot"
+}
+
+variable "role" {
+  description = "Role name"
+  default     = "AWSLambdaSecretManagerRole"
+}
+
+variable "policy" {
+  description = "Policy name"
+  default     = "AWSLambdaSecretManager"
+}


### PR DESCRIPTION
path.module returns an absolute path. This causes terraform to mark
the lambda function as changing whenever a plan is performed at a
different path. This happens often when different users perform a
plan or apply. In Terraform v0.12 path.module returns a relative
path. To work around this issue in version 0.11 we are hard coding
a relative path that matches the value of path.module in v0.12.

In addition, variables were added for testing & portability, and
the documentation was updated to reflect these changes.

Closes #1